### PR TITLE
refactor: adjust RecordButton spacing

### DIFF
--- a/components/RecordButton.tsx
+++ b/components/RecordButton.tsx
@@ -11,6 +11,7 @@ export default function RecordButton({ onPress }:{ onPress:()=>void }) {
     );
 }
 const styles = StyleSheet.create({
-    btn:{ height:48, borderRadius:16, backgroundColor:'#0B2239', flexDirection:'row', alignItems:'center', justifyContent:'center', gap:8 },
-    icon:{ color:'#fff', fontSize:16 }, txt:{ color:'#fff', fontSize:14, fontWeight:'600' },
+    btn:{ height:48, borderRadius:16, backgroundColor:'#0B2239', flexDirection:'row', alignItems:'center', justifyContent:'center' },
+    icon:{ color:'#fff', fontSize:16 },
+    txt:{ color:'#fff', fontSize:14, fontWeight:'600', marginLeft:8 },
 });


### PR DESCRIPTION
## Summary
- remove unsupported gap style from RecordButton
- use margin-left on text label to maintain spacing between icon and text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf1a87c808326b7841ba28e89708a